### PR TITLE
Omit some files and lines when measure code coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,10 @@
+[run]
+omit =
+    */tests/*
+    thenewboston_node/manage.py
+    thenewboston_node/project/*
+
+[report]
+exclude_lines =
+    pragma: no cover
+    raise NotImplementedError

--- a/thenewboston_node/business_logic/blockchain/mock_blockchain.py
+++ b/thenewboston_node/business_logic/blockchain/mock_blockchain.py
@@ -1,7 +1,7 @@
 from .base import BlockchainBase
 
 
-class MockBlockchain(BlockchainBase):
+class MockBlockchain(BlockchainBase):  # pragma: no cover
     """
     A blockchain dummy "implementation" to be mocked in unittests
     """


### PR DESCRIPTION
#67 
Omit:
    1. django project files
    2. abstract class methods
    3. mocks